### PR TITLE
If clustering, always cluster

### DIFF
--- a/app/sirius/core/aggregations.py
+++ b/app/sirius/core/aggregations.py
@@ -32,25 +32,22 @@ def cluster_r_data(r_data_in_range, sampling_rate, track_height_px):
         r_cluster = r_data_in_range[c_begin: c_end+1]
         c_size = len(r_cluster)
         total_annotations += c_size
-        if c_size > 1:
-            label = str(c_size)
-            startBp = r_cluster[0]['startBp']
-            endBp = r_cluster[-1]['endBp']
-            color_level = max(min(c_size / 100, 1.0), 0.2) # between (0.2~1.0)
-            color = [0.15, 0.55, 1.0, color_level]
-            r_data = {'id': 'cluster',
-                      'count': c_size,
-                      'startBp': startBp,
-                      'endBp': endBp,
-                      'labels': [[label, True, 4, 0, 0]],
-                      'yOffsetPx': 0,
-                      'heightPx': track_height_px,
-                      'segments': [[0, endBp-startBp+1, None, color, 20]],
-                      'aggregation': True
-                     }
+        label = str(c_size)
+        startBp = r_cluster[0]['startBp']
+        endBp = r_cluster[-1]['endBp']
+        color_level = max(min(c_size / 100, 1.0), 0.2) # between (0.2~1.0)
+        color = [0.15, 0.55, 1.0, color_level]
+        r_data = {'id': 'cluster',
+                  'count': c_size,
+                  'startBp': startBp,
+                  'endBp': endBp,
+                  'labels': [[label, True, 4, 0, 0]],
+                  'yOffsetPx': 0,
+                  'heightPx': track_height_px,
+                  'segments': [[0, endBp-startBp+1, None, color, 20]],
+                  'aggregation': True
+                 }
             ret.append(r_data)
-        else:
-            ret += r_cluster
         c_begin = c_end+1
     return ret, total_annotations
 


### PR DESCRIPTION
For visual display, I think we want consistent visual semantics between aggregated and non-aggregated tracks