### PR TITLE
add optional user requested info fields for interval data

### DIFF
--- a/app/sirius/core/interval_track.py
+++ b/app/sirius/core/interval_track.py
@@ -4,10 +4,12 @@ from sirius.core.utilities import HashableDict, threadsafe_lru
 from sirius.query.query_tree import QueryTree
 from sirius.helpers.loaddata import loaded_genome_contigs
 
-def get_intervals_in_range(contig, start_bp, end_bp, query, verbose=True, fields=None):
+def get_intervals_in_range(contig, start_bp, end_bp, query, fields=None, verbose=True):
+    # default fields to empty list
+    if fields is None: fields = []
     # lode cached data
     t0 = time.time()
-    query_genome_data, query_start_bps = get_interval_query_results(HashableDict(query))
+    query_genome_data, query_start_bps = get_interval_query_results(HashableDict(query), tuple(sorted(fields)))
     contig_genome_data = query_genome_data[contig]
     contig_start_bps = query_start_bps[contig]
     total_query_count = len(contig_genome_data)
@@ -26,28 +28,27 @@ def get_intervals_in_range(contig, start_bp, end_bp, query, verbose=True, fields
     # form return format
     result = []
     for d in genome_data_in_range:
-        curr_fields = {}
-        if fields:
-            for field in fields:
-                curr_fields[field] = d[field] if field in d else None
-        result.append({
+        ret_d = {
             'id': d['_id'],
             'start': d['start'],
             'length': d['length'],
             'type': d['type'],
             'name': d['name'],
-            'info' : curr_fields
-        })
+        }
+        if 'info' in d:
+            ret_d['info'] = d['info']
+        result.append(ret_d)
     return result
 
 @threadsafe_lru(maxsize=8192)
-def get_interval_query_results(query):
+def get_interval_query_results(query, fields):
     print(f'-----thread running {query}')
     qt = QueryTree(query)
     # we split the results into contigs
     genome_data = {contig: [] for contig in loaded_genome_contigs}
     # put the results in to cache
-    for gnode in qt.find(projection=['_id', 'contig', 'start', 'length', 'type', 'name']):
+    projection = ['_id', 'contig', 'start', 'length', 'type', 'name'] + list(fields)
+    for gnode in qt.find(projection=projection):
         contig = gnode.pop('contig')
         genome_data[contig].append(gnode)
     # sort the results based on the start

--- a/app/sirius/core/views.py
+++ b/app/sirius/core/views.py
@@ -496,10 +496,8 @@ def get_interval_track_data(contig, start_bp, end_bp):
     t0 = time.time()
     query = request.get_json()
     fields = request.args.get('fields', None)
-    
     if fields:
         fields = fields.split(',')
-
     if not query:
         return abort(404, 'no query specified')
     if contig not in loaded_contig_info_dict:
@@ -508,8 +506,8 @@ def get_interval_track_data(contig, start_bp, end_bp):
         'contig': contig,
         'start_bp': start_bp,
         'end_bp': end_bp,
+        'fields': fields,
         'data': [],
-        'fields': fields
     })
     total_length = loaded_contig_info_dict[contig]['length']
     # check start_bp and end_bp
@@ -519,12 +517,13 @@ def get_interval_track_data(contig, start_bp, end_bp):
     start_bp = max(start_bp, 1)
     end_bp = min(end_bp, total_length)
     t1 = time.time()
-    result_data = get_intervals_in_range(contig, start_bp, end_bp, query, fields)
+    result_data = get_intervals_in_range(contig, start_bp, end_bp, query, fields=fields)
     result = {
         'contig': contig,
         'start_bp': start_bp,
         'end_bp': end_bp,
-        'data': result_data
+        'fields': fields,
+        'data': result_data,
     }
     t2 = time.time()
     print(f'{len(result_data)} interval_data, {query}, parse {t1-t0:.2f} s | load {t2-t1:.2f} s')


### PR DESCRIPTION
For ImmuneAtlas the frontend will need to render a color for each interval based on the 'count' field, this API extension enables the client to request a specific list of fields to include in the output (inputted as a comma separated values in the GET parameter)