### PR TITLE
Improve Promoter/Enhancer suggestions for token box

### DIFF
--- a/app/sirius/core/searchindex.py
+++ b/app/sirius/core/searchindex.py
@@ -8,7 +8,7 @@ import fuzzyset
 import numpy as np
 
 from sirius.helpers.loaddata import loaded_gene_names, loaded_trait_names, \
-    loaded_patient_tumor_sites, loaded_info_targets, loaded_pathway_names,
+    loaded_patient_tumor_sites, loaded_info_targets, loaded_pathway_names
 from sirius.helpers.loaddata import loaded_cell_types, loaded_cell_types_promoter, loaded_cell_types_enhancer
 
 

--- a/app/sirius/helpers/loaddata.py
+++ b/app/sirius/helpers/loaddata.py
@@ -111,4 +111,6 @@ print(f'Loaded {len(loaded_pathway_names)} pathway')
 
 # type specific cell types for encode tokenbox
 loaded_cell_types_promoter = sorted(InfoNodes.distinct('info.biosample', {'type': 'ENCODE_accession', 'info.types': 'Promoter-like'}))
+print(f'Loaded {len(loaded_cell_types_promoter)} cell types for promoters')
 loaded_cell_types_enhancer = sorted(InfoNodes.distinct('info.biosample', {'type': 'ENCODE_accession', 'info.types': 'Enhancer-like'}))
+print(f'Loaded {len(loaded_cell_types_enhancer)} cell types for enhancers')


### PR DESCRIPTION
Two new tokens are supported in /suggestions endpoint: `CELL_TYPE_PROMOTER` and `CELL_TYPE_ENHANCER`

This allows providing valid cell-type suggestions from ENCODE dataset to the frontend.